### PR TITLE
corsの最適化

### DIFF
--- a/src/infrastructure/rest-api/cors.ts
+++ b/src/infrastructure/rest-api/cors.ts
@@ -2,37 +2,17 @@ import express from 'express'
 import cors from 'cors'
 
 // 開発中用cors設定
-const devCorsMiddleware = (
-  req: express.Request,
-  res: express.Response,
-  next: () => void
-) => {
-  /* originをオウム返し
-     Credentialsがtrueの時、ワイルドカードが使えない  */
-  res.header(
-    'Access-Control-Allow-Origin',
-    req.headers.origin ? req.headers.origin.toString() : ''
-  )
-  res.header('Access-Control-Allow-Credentials', 'true')
-  res.header(
-    'Access-Control-Allow-Methods',
-    'GET,POST,PUT,PATCH,DELETE,HEAD,OPTIONS'
-  )
-  res.header('Access-Control-Allow-Headers', 'Content-Type')
-  if (req.method === 'OPTIONS') {
-    res.sendStatus(200)
-    return
-  }
-  next()
-}
+const devCorsMiddleware = cors({
+  origin: /.*/,
+  credentials: true
+})
 
 // プロダクション用cors設定
 const prodCorsMiddleware = cors({
   origin: [
-    'https://twinte.net',
-    'https://app.twinte.net',
-    'https://dev.twinte.net',
-    'https://twins.tsukuba.ac.jp'
+    /https:\/\/(.+\.)*twinte\.net$/,
+    'https://twins.tsukuba.ac.jp',
+    /localhost(:\d{1,5})?$/
   ],
   credentials: true
 })


### PR DESCRIPTION
- devモードではすべてのドメインを受け付けるように
- prodモードではtwinte.net（サブドメインも含む）と、twins、localhostを受け付けるようにした