### PR TITLE
寄付完了時にフロントに金額を渡すように

### DIFF
--- a/src/di/inversify.config.ts
+++ b/src/di/inversify.config.ts
@@ -37,6 +37,8 @@ import { StripeSubscriptionRepository } from '../infrastructure/payment/StripeSu
 import { FindSubscriptionInteractor } from '../interactor/payment/findSubscriptionInteractor'
 import { UpdatePaymentUserInteractor } from '../interactor/payment/updatePaymentUserInteractor'
 import { GetAllPaidUserInteractor } from '../interactor/payment/GetAllPaidUserInteractor'
+import { FindCheckoutInteractor } from '../interactor/payment/findCheckoutInteractor'
+import { GetCheckoutInfoInteractor } from '../interactor/payment/getCheckoutInfoInteractor'
 
 const config: { identifier: any; bindTo: any }[] = [
   { identifier: types.LectureRepository, bindTo: PLectureRepository },
@@ -129,7 +131,12 @@ const config: { identifier: any; bindTo: any }[] = [
     identifier: types.UpdatePaymentUserUseCase,
     bindTo: UpdatePaymentUserInteractor
   },
-  { identifier: types.GetAllPaidUserUseCase, bindTo: GetAllPaidUserInteractor }
+  { identifier: types.GetAllPaidUserUseCase, bindTo: GetAllPaidUserInteractor },
+  { identifier: types.FindCheckoutUseCase, bindTo: FindCheckoutInteractor },
+  {
+    identifier: types.GetCheckoutInfoUseCase,
+    bindTo: GetCheckoutInfoInteractor
+  }
 ]
 
 const container = new Container()

--- a/src/di/types.ts
+++ b/src/di/types.ts
@@ -30,7 +30,9 @@ const types = {
   CreatePaymentUserUseCase: Symbol.for('CreatePaymentUserUseCase'),
   FindSubscriptionUseCase: Symbol.for('FindSubscriptionUseCase'),
   UpdatePaymentUserUseCase: Symbol.for('UpdatePaymentUserUseCase'),
-  GetAllPaidUserUseCase: Symbol.for('GetAllPaidUserUseCase')
+  GetAllPaidUserUseCase: Symbol.for('GetAllPaidUserUseCase'),
+  FindCheckoutUseCase: Symbol.for('FindCheckoutUseCase'),
+  GetCheckoutInfoUseCase: Symbol.for('GetCheckoutInfoUseCase')
 }
 
 export { types }

--- a/src/infrastructure/payment/StripeCheckoutSessionRepository.ts
+++ b/src/infrastructure/payment/StripeCheckoutSessionRepository.ts
@@ -18,20 +18,19 @@ export class StripeCheckoutSessionRepository
   ): Promise<string> {
     const session = await stripe.checkout.sessions.create({
       payment_method_types: ['card'],
+      submit_type: 'donate',
       customer: paymentUser ? paymentUser.payment_user_id : undefined,
       line_items: [
         {
           name: 'Twin:te寄付',
           description: '寄付いただいたお金はTwin:teの運用や開発に使用します',
-          images: [
-            'https://wonderful-goldwasser-531adc.netlify.com/Twintelogo-colorA.a9fc046b.png'
-          ],
+          images: ['https://www.twinte.net/ogp.jpg'],
           amount,
           currency: 'jpy',
           quantity: 1
         }
       ],
-      success_url: process.env.STRIPE_SUCCESS_URL!!,
+      success_url: `${process.env.BASE_URL}/v1/payment/success?session_id={CHECKOUT_SESSION_ID}`,
       cancel_url: process.env.STRIPE_CANCEL_URL!!
     })
     return session.id
@@ -43,6 +42,7 @@ export class StripeCheckoutSessionRepository
   ): Promise<string> {
     const session = await stripe.checkout.sessions.create({
       payment_method_types: ['card'],
+      submit_type: 'donate',
       customer: paymentUser.payment_user_id,
       subscription_data: {
         items: [
@@ -51,7 +51,7 @@ export class StripeCheckoutSessionRepository
           }
         ]
       },
-      success_url: process.env.STRIPE_SUCCESS_URL!!,
+      success_url: `${process.env.BASE_URL}/v1/payment/success?session_id={CHECKOUT_SESSION_ID}`,
       cancel_url: process.env.STRIPE_CANCEL_URL!!
     })
     return session.id

--- a/src/infrastructure/payment/StripePaymentRepository.ts
+++ b/src/infrastructure/payment/StripePaymentRepository.ts
@@ -1,12 +1,17 @@
-import { injectable } from 'inversify'
-import { PaymentRepository } from '../../interface/repository/payment/paymentRepository'
-import { PaymentUser } from '../../entity/payment/paymentUser'
-import { stripe } from './stripe'
-import { Stripe } from 'stripe'
-import { Payment } from '../../entity/payment/payment'
+import {inject, injectable} from 'inversify'
+import {PaymentRepository} from '../../interface/repository/payment/paymentRepository'
+import {PaymentUser} from '../../entity/payment/paymentUser'
+import {stripe} from './stripe'
+import {Stripe} from 'stripe'
+import {Payment} from '../../entity/payment/payment'
+import {types} from '../../di/types'
+import {PaymentUserRepository} from '../../interface/repository/payment/paymentUserRepository'
 
 @injectable()
 export class StripePaymentRepository implements PaymentRepository {
+  @inject(types.PaymentUserRepository)
+  paymentUserRepository!: PaymentUserRepository
+
   private async find(paymentUser?: PaymentUser) {
     const payments: Payment[] = []
     // 一回限りの支払いを取得
@@ -27,22 +32,29 @@ export class StripePaymentRepository implements PaymentRepository {
 
     payments.push(
       ...intents.data.map((i: Stripe.PaymentIntent) => {
-        const obj: Payment = {
-          type: i.invoice ? 'Subscription' : 'OneTime',
-          id: i.id,
-          paymentUser: paymentUser ? paymentUser : null,
-          amount: i.amount,
-          paid_at: i.status === 'succeeded' ? i.created : null,
-          status:
-            i.status === 'succeeded' || i.status === 'canceled'
-              ? i.status
-              : 'pending'
-        }
-        return obj
+        return this.stripePaymentIntentToPaymentObject(i, paymentUser)
       })
     )
 
     return payments
+  }
+
+  private stripePaymentIntentToPaymentObject(
+    i: Stripe.PaymentIntent,
+    paymentUser?: PaymentUser
+  ) {
+    const obj: Payment = {
+      type: i.invoice ? 'Subscription' : 'OneTime',
+      id: i.id,
+      paymentUser: paymentUser ? paymentUser : null,
+      amount: i.amount,
+      paid_at: i.status === 'succeeded' ? i.created : null,
+      status:
+        i.status === 'succeeded' || i.status === 'canceled'
+          ? i.status
+          : 'pending'
+    }
+    return obj
   }
 
   async findByPaymentUser(paymentUser: PaymentUser): Promise<Payment[]> {
@@ -72,5 +84,14 @@ export class StripePaymentRepository implements PaymentRepository {
       lastID = intents.data.slice(-1)[0].id
     }
     return sum
+  }
+
+  async findByPaymentID(id: string): Promise<Payment | undefined> {
+    const intent = await stripe.paymentIntents.retrieve(id)
+    if (!intent) return undefined
+    const paymentUser = await this.paymentUserRepository.findPaymentUser(
+      typeof intent.customer === 'string' ? intent.customer : intent.id
+    )
+    return this.stripePaymentIntentToPaymentObject(intent, paymentUser)
   }
 }

--- a/src/infrastructure/payment/StripeSubscriptionRepository.ts
+++ b/src/infrastructure/payment/StripeSubscriptionRepository.ts
@@ -11,7 +11,7 @@ import { PaymentUser } from '../../entity/payment/paymentUser'
 export class StripeSubscriptionRepository implements SubscriptionRepository {
   @inject(types.FindPaymentUserUseCase)
   findPaymentUserUseCase!: FindPaymentUserUseCase
-  async find(subscription_id: string): Promise<Subscription> {
+  async find(subscription_id: string): Promise<Subscription | undefined> {
     const sub = await stripe.subscriptions.retrieve(subscription_id)
     const paymentUser = await this.findPaymentUserUseCase.findPaymentUser(
       typeof sub.customer === 'string' ? sub.customer : sub.customer.id

--- a/src/interactor/payment/findCheckoutInteractor.ts
+++ b/src/interactor/payment/findCheckoutInteractor.ts
@@ -1,0 +1,14 @@
+import { FindCheckoutUseCase } from '../../usecase/payment/findCheckoutUseCase'
+import { CheckoutSession } from '../../entity/payment/checkoutSession'
+import {inject, injectable} from 'inversify'
+import { types } from '../../di/types'
+import { CheckoutSessionRepository } from '../../interface/repository/payment/checkoutSessionRepository'
+
+@injectable()
+export class FindCheckoutInteractor implements FindCheckoutUseCase {
+  @inject(types.CheckoutSessionRepository)
+  checkoutSessionRepository!: CheckoutSessionRepository
+  findCheckout(checkoutID: string): Promise<CheckoutSession | undefined> {
+    return this.checkoutSessionRepository.find(checkoutID)
+  }
+}

--- a/src/interactor/payment/findPaymentInteractor.ts
+++ b/src/interactor/payment/findPaymentInteractor.ts
@@ -19,4 +19,8 @@ export class FindPaymentInteractor implements FindPaymentUseCase {
   getTotalAmount(): Promise<number> {
     return this.paymentRepository.getTotalAmount()
   }
+
+  findByPaymentID(id: string): Promise<Payment | undefined> {
+    return this.paymentRepository.findByPaymentID(id)
+  }
 }

--- a/src/interactor/payment/findSubscriptionInteractor.ts
+++ b/src/interactor/payment/findSubscriptionInteractor.ts
@@ -10,7 +10,7 @@ export class FindSubscriptionInteractor implements FindSubscriptionUseCase {
   @inject(types.SubscriptionRepository)
   subscriptionRepository!: SubscriptionRepository
 
-  findSubscription(subscription_id: string): Promise<Subscription> {
+  findSubscription(subscription_id: string): Promise<Subscription | undefined> {
     return this.subscriptionRepository.find(subscription_id)
   }
 

--- a/src/interactor/payment/getCheckoutInfoInteractor.ts
+++ b/src/interactor/payment/getCheckoutInfoInteractor.ts
@@ -1,0 +1,39 @@
+import {
+  CheckoutInfo,
+  GetCheckoutInfoUseCase
+} from '../../usecase/payment/getCheckoutInfoUseCase'
+import {inject, injectable} from 'inversify'
+import { types } from '../../di/types'
+import { CheckoutSessionRepository } from '../../interface/repository/payment/checkoutSessionRepository'
+import { SubscriptionRepository } from '../../interface/repository/payment/subscriptionRepository'
+import { PaymentRepository } from '../../interface/repository/payment/paymentRepository'
+
+@injectable()
+export class GetCheckoutInfoInteractor implements GetCheckoutInfoUseCase {
+  @inject(types.CheckoutSessionRepository)
+  checkoutSessionRepository!: CheckoutSessionRepository
+  @inject(types.SubscriptionRepository)
+  subscriptionRepository!: SubscriptionRepository
+  @inject(types.PaymentRepository) paymentRepository!: PaymentRepository
+  async getCheckoutInfo(checkoutID: string): Promise<CheckoutInfo | undefined> {
+    const checkout = await this.checkoutSessionRepository.find(checkoutID)
+    if (!checkout) return undefined
+    if (checkout.type === 'OneTime') {
+      const intent = await this.paymentRepository.findByPaymentID(
+        checkout.payment_intent
+      )
+      if (!intent) return undefined
+      return {
+        type: 'OneTime',
+        amount: intent.amount
+      }
+    } else {
+      const sub = await this.subscriptionRepository.find(checkout.subscription)
+      if (!sub) return undefined
+      return {
+        type: 'Subscription',
+        plan: sub.plan
+      }
+    }
+  }
+}

--- a/src/interface/controller/paymentController.ts
+++ b/src/interface/controller/paymentController.ts
@@ -12,6 +12,10 @@ import { Subscription } from '../../entity/payment/subscription'
 import { UpdatePaymentUserUseCase } from '../../usecase/payment/updatePaymentUserUseCase'
 import { PaymentUser } from '../../entity/payment/paymentUser'
 import { GetAllPaidUserUseCase } from './getAllPaidUserUseCase'
+import {
+  CheckoutInfo,
+  GetCheckoutInfoUseCase
+} from '../../usecase/payment/getCheckoutInfoUseCase'
 
 @injectable()
 export class PaymentController {
@@ -39,6 +43,9 @@ export class PaymentController {
   @inject(types.GetAllPaidUserUseCase)
   private getAllPaidUserUseCase!: GetAllPaidUserUseCase
 
+  @inject(types.GetCheckoutInfoUseCase)
+  private getCheckoutInfoUseCase!: GetCheckoutInfoUseCase
+
   async createOneTimeCheckoutSession(
     amount: number,
     user?: UserEntity
@@ -50,6 +57,7 @@ export class PaymentController {
         : undefined
     )
   }
+
   async createSubscriptionCheckoutSession(
     plan_id: string,
     user: UserEntity
@@ -86,7 +94,7 @@ export class PaymentController {
     )
   }
 
-  findSubscription(subscription_id: string): Promise<Subscription> {
+  findSubscription(subscription_id: string): Promise<Subscription | undefined> {
     return this.findSubscriptionUseCase.findSubscription(subscription_id)
   }
 
@@ -111,6 +119,12 @@ export class PaymentController {
     return this.findPaymentUserUseCase.findPaymentUserByTwinteUserId(
       user.twinte_user_id
     )
+  }
+
+  getCheckoutSessionInfo(
+    checkoutID: string
+  ): Promise<CheckoutInfo | undefined> {
+    return this.getCheckoutInfoUseCase.getCheckoutInfo(checkoutID)
   }
 
   async getAllPaidUsers(): Promise<{

--- a/src/interface/repository/payment/paymentRepository.ts
+++ b/src/interface/repository/payment/paymentRepository.ts
@@ -1,8 +1,9 @@
-import {PaymentUser} from '../../../entity/payment/paymentUser'
-import {Payment} from '../../../entity/payment/payment'
+import { PaymentUser } from '../../../entity/payment/paymentUser'
+import { Payment } from '../../../entity/payment/payment'
 
 export interface PaymentRepository {
   findByPaymentUser(paymentUser: PaymentUser): Promise<Payment[]>
-  getAll() : Promise<Payment[]>
+  findByPaymentID(id: string): Promise<Payment | undefined>
+  getAll(): Promise<Payment[]>
   getTotalAmount(): Promise<number>
 }

--- a/src/interface/repository/payment/subscriptionRepository.ts
+++ b/src/interface/repository/payment/subscriptionRepository.ts
@@ -2,7 +2,7 @@ import { Subscription } from '../../../entity/payment/subscription'
 import { PaymentUser } from '../../../entity/payment/paymentUser'
 
 export interface SubscriptionRepository {
-  find(subscription_id: string): Promise<Subscription>
+  find(subscription_id: string): Promise<Subscription | undefined>
   findByPaymentUser(paymentUser: PaymentUser): Promise<Subscription[]>
   unsubscribe(subscription_id: string): Promise<void>
 }

--- a/src/usecase/payment/findCheckoutUseCase.ts
+++ b/src/usecase/payment/findCheckoutUseCase.ts
@@ -1,0 +1,5 @@
+import { CheckoutSession } from '../../entity/payment/checkoutSession'
+
+export interface FindCheckoutUseCase {
+  findCheckout(checkoutID: string): Promise<CheckoutSession | undefined>
+}

--- a/src/usecase/payment/findPaymentUseCase.ts
+++ b/src/usecase/payment/findPaymentUseCase.ts
@@ -3,6 +3,7 @@ import { Payment } from '../../entity/payment/payment'
 
 export interface FindPaymentUseCase {
   findByPaymentUser(paymentUser: PaymentUser): Promise<Payment[]>
+  findByPaymentID(id: string): Promise<Payment | undefined>
   getAllPayment(): Promise<Payment[]>
   getTotalAmount(): Promise<number>
 }

--- a/src/usecase/payment/findSubscriptionUseCase.ts
+++ b/src/usecase/payment/findSubscriptionUseCase.ts
@@ -5,5 +5,5 @@ export interface FindSubscriptionUseCase {
   findSubscriptionByPaymentUser(
     paymentUser: PaymentUser
   ): Promise<Subscription[]>
-  findSubscription(subscription_id: string): Promise<Subscription>
+  findSubscription(subscription_id: string): Promise<Subscription | undefined>
 }

--- a/src/usecase/payment/getCheckoutInfoUseCase.ts
+++ b/src/usecase/payment/getCheckoutInfoUseCase.ts
@@ -1,0 +1,17 @@
+import {Plan} from '../../entity/payment/subscription'
+
+export interface GetCheckoutInfoUseCase {
+  getCheckoutInfo(checkoutID: string): Promise<CheckoutInfo | undefined>
+}
+
+export type OneTimeCheckoutInfo = {
+  type: 'OneTime'
+  amount: number
+}
+
+export type SubscriptionCheckoutInfo = {
+  type: 'Subscription'
+  plan: Plan[]
+}
+
+export type CheckoutInfo = OneTimeCheckoutInfo | SubscriptionCheckoutInfo


### PR DESCRIPTION
#21
決済完了後のurlに

{指定したurl}?type=onetime&amount=100
{指定したurl}?type=subscription&amount=100

みたいなクエリが載ります

![image](https://user-images.githubusercontent.com/17082836/76235793-f8e67980-626e-11ea-8a88-fcf010407750.png)
あと、決済ボタンの文言を「寄付」に変更しました