### PR TITLE
振替日一覧を取得するエンドポイント追加

### DIFF
--- a/src/infrastructure/database/pSchoolCalenderRepository.ts
+++ b/src/infrastructure/database/pSchoolCalenderRepository.ts
@@ -53,8 +53,8 @@ export class PSchoolCalenderRepository implements SchoolCalenderRepository {
     const res = await this.substituteDayRepository.find({
       date: Raw(
         alias =>
-          `${alias} >= '${year}-01-01'::date and ${alias} <= '${year +
-            1}-12-31'::date`
+          `${alias} >= '${year}-04-01'::date and ${alias} <= '${year +
+            1}-03-31'::date`
       )
     })
     return res.map(el => ({

--- a/src/infrastructure/rest-api/routing/schoolCalenderService.ts
+++ b/src/infrastructure/rest-api/routing/schoolCalenderService.ts
@@ -1,5 +1,8 @@
-import { GET, Path, PathParam } from 'typescript-rest'
-import { SchoolCalenderController } from '../../../interface/controller/schoolCalenderController'
+import { GET, Path, PathParam, QueryParam } from 'typescript-rest'
+import {
+  SchoolCalenderController,
+  OutputSubstituteDay
+} from '../../../interface/controller/schoolCalenderController'
 import container from '../../../di/inversify.config'
 import { OutputSchoolCalender } from '../../../interface/controller/schoolCalenderController'
 import { Response, Tags } from 'typescript-rest-swagger'
@@ -11,6 +14,17 @@ export class SchoolCalenderService {
 
   constructor() {
     this.schoolCalenderController = container.get(SchoolCalenderController)
+  }
+
+  /**
+   * 指定された年度の振替授業日一覧を取得する
+   * @param year 年度
+   */
+  @Path('/substitutes/list')
+  @GET
+  @Response<OutputSubstituteDay[]>(200, '指定された年度の振替日一覧')
+  getSubstituteDays(@QueryParam('year') year: number) {
+    return this.schoolCalenderController.getSubstituteDays(year)
   }
 
   /**

--- a/src/interface/controller/schoolCalenderController.ts
+++ b/src/interface/controller/schoolCalenderController.ts
@@ -13,7 +13,7 @@ interface OutputEvent {
   date: string
 }
 
-interface OutputSubstituteDay {
+export interface OutputSubstituteDay {
   date: string
   change_to: Day
 }
@@ -60,5 +60,14 @@ export class SchoolCalenderController {
       substituteDay: outputSubstitute,
       module
     }
+  }
+
+  async getSubstituteDays(year: number): Promise<OutputSubstituteDay[]> {
+    return (await this.getSchoolCalenderUseCae.getSubstituteDays(year)).map(
+      s => ({
+        date: s.date.format('YYYY-MM-DD'),
+        change_to: s.change_to
+      })
+    )
   }
 }


### PR DESCRIPTION
`/school-calendar/substitutes/list` で取れます
使用してるフレームワークの仕様でurlがちょっとおかしいけど目をつぶって