### PR TITLE
csvダウンロードエンドポイントを追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "pgtools": "^0.3.0",
     "reflect-metadata": "^0.1.13",
     "stripe": "^8.4.0",
-    "twinte-parser": "^1.2.3",
+    "twinte-parser": "1.2.3",
     "typeorm": "^0.2.20",
     "typescript-rest": "^2.2.2",
     "typescript-rest-swagger": "^1.0.4",

--- a/src/infrastructure/database/pUserLectureRepository.ts
+++ b/src/infrastructure/database/pUserLectureRepository.ts
@@ -164,4 +164,15 @@ export class PUserLectureRepository implements UserLectureRepository {
       instructor: p.instructor
     }
   }
+
+  async getLectureCodes(user: UserEntity, year: number): Promise<string[]> {
+    const res = await this.userLectureRepository.find({
+      where: { user, year },
+      relations: ['twinte_lecture']
+    })
+    return res
+      .map(ul => ul.twinte_lecture?.lecture_code)
+      .filter(e => e)
+      .map(e => e!!)
+  }
 }

--- a/src/infrastructure/rest-api/routing/userLectureService.ts
+++ b/src/infrastructure/rest-api/routing/userLectureService.ts
@@ -111,4 +111,19 @@ export class UserLectureService {
       user_lecture_id
     )
   }
+
+  @GET
+  @Path('/lecture-code-csv/:year')
+  async getLectureCodes(@PathParam('year') year: number) {
+    this.context.response.setHeader('Content-Type', 'text/csv')
+    this.context.response.setHeader(
+      'Content-Disposition',
+      `attachment; filename="${year}.csv"`
+    )
+    const res = await this.userLectureController.getLectureCodes(
+      this.context.request.user!!,
+      year
+    )
+    this.context.response.send(res.reduce((all, c) => `${all}\n${c}`))
+  }
 }

--- a/src/interactor/findUserLectureInteractor.ts
+++ b/src/interactor/findUserLectureInteractor.ts
@@ -20,4 +20,8 @@ export class FindUserLectureInteractor implements FindUserLectureUseCase {
   getAllUserLectures(user: UserEntity): Promise<UserLectureEntity[]> {
     return this.userLectureRepository.getAllUserLecture(user)
   }
+
+  getLectureCodes(user: UserEntity, year: number): Promise<string[]> {
+    return this.userLectureRepository.getLectureCodes(user, year)
+  }
 }

--- a/src/interface/controller/userLectureController.ts
+++ b/src/interface/controller/userLectureController.ts
@@ -59,4 +59,8 @@ export class UserLectureController {
   ): Promise<UserLectureEntity | undefined> {
     return this.updateUserLectureUseCase.updateUserLecture(user, userLecture)
   }
+
+  getLectureCodes(user: UserEntity, year: number): Promise<string[]> {
+    return this.findUserLectureUseCase.getLectureCodes(user, year)
+  }
 }

--- a/src/interface/repository/userLectureRepository.ts
+++ b/src/interface/repository/userLectureRepository.ts
@@ -22,4 +22,5 @@ export interface UserLectureRepository {
     userLecture: UserLectureEntity
   ): Promise<UserLectureEntity | undefined>
   removeUserLecture(user: UserEntity, user_lecture_id: string): Promise<boolean>
+  getLectureCodes(user: UserEntity, year: number): Promise<string[]>
 }

--- a/src/usecase/findUserLectureUseCase.ts
+++ b/src/usecase/findUserLectureUseCase.ts
@@ -7,4 +7,5 @@ export interface FindUserLectureUseCase {
     user_lecture_id: string
   ): Promise<UserLectureEntity | undefined>
   getAllUserLectures(user: UserEntity): Promise<UserLectureEntity[]>
+  getLectureCodes(user: UserEntity, year: number): Promise<string[]>
 }


### PR DESCRIPTION
twinsにインポートできるcsvを吐くエンドポイント
`/v1/user-lectures/lecture-code-csv/2020`
を追加した。
ブラウザで開くとcsvダウンロードされるから
aタグで別ウィンドウで開くとかすればよいかと