### PR TITLE
Feature/#40

### DIFF
--- a/__tests__/repository/lectureRepository.spec.ts
+++ b/__tests__/repository/lectureRepository.spec.ts
@@ -22,6 +22,11 @@ beforeAll(async () => {
       year: 2019,
       twinte_lecture_id: '',
       instructor: 'Twin:te',
+      overview: 'overview',
+      remarks: 'remarks',
+      standardYear: [1, 2],
+      credits: 1.5,
+      type: 1,
       details: [
         { module: Module.SpringA, day: Day.Mon, period: 1, room: '3A404' }
       ]

--- a/__tests__/repository/timetableRepository.spec.ts
+++ b/__tests__/repository/timetableRepository.spec.ts
@@ -56,6 +56,11 @@ beforeAll(async () => {
       year: 2019,
       twinte_lecture_id: '',
       instructor: 'Twin:te',
+      credits: 2,
+      standardYear: [1, 2],
+      overview: 'overview',
+      remarks: 'remarks',
+      type: 1,
       details: [
         { module: Module.SpringA, day: Day.Mon, period: 1, room: '3A404' }
       ]
@@ -69,13 +74,15 @@ beforeAll(async () => {
   const customUserLecture = {
     year: 2019,
     lecture_name: '講義C',
-    instructor: 'Twin-te'
+    instructor: 'Twin-te',
+    credits: 2
   }
   testCustomUserLecture = await userLectureRepository.createCustomUserLecture(
     testUser,
     customUserLecture.year,
     customUserLecture.lecture_name,
-    customUserLecture.instructor
+    customUserLecture.instructor,
+    customUserLecture.credits
   )
 })
 let testPeriod: PeriodEntity

--- a/__tests__/repository/userLectureRepository.spec.ts
+++ b/__tests__/repository/userLectureRepository.spec.ts
@@ -47,6 +47,11 @@ beforeAll(async () => {
       year: 2019,
       twinte_lecture_id: '',
       instructor: 'Twin:te',
+      credits: 2,
+      standardYear: [1, 2],
+      overview: 'overview',
+      remarks: 'remarks',
+      type: 1,
       details: [
         { module: Module.SpringA, day: Day.Mon, period: 1, room: '3A404' }
       ]
@@ -70,6 +75,7 @@ test('CreateUserLecture', async () => {
   expect(res!!.late).toBe(0)
   expect(res!!.absence).toBe(0)
   expect(res!!.memo).toBe('')
+  expect(res!!.credits).toBe(2)
   testUserLecture = res!!
 })
 
@@ -100,13 +106,15 @@ test('CreateCustomUserLecture', async () => {
   const customUserLecture = {
     year: 2019,
     lecture_name: '講義C',
-    instructor: 'Twin-te'
+    instructor: 'Twin-te',
+    credits: 2
   }
   const res = await userLectureRepository.createCustomUserLecture(
     testUser,
     customUserLecture.year,
     customUserLecture.lecture_name,
-    customUserLecture.instructor
+    customUserLecture.instructor,
+    customUserLecture.credits
   )
   expect(res).toBeTruthy()
   expect(res!!.twinte_lecture_id).toBeNull()

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "pgtools": "^0.3.0",
     "reflect-metadata": "^0.1.13",
     "stripe": "^8.4.0",
-    "twinte-parser": "1.2.3",
+    "twinte-parser": "1.3.1",
     "typeorm": "^0.2.20",
     "typescript-rest": "^2.2.2",
     "typescript-rest-swagger": "^1.0.4",

--- a/src/entity/lecture.ts
+++ b/src/entity/lecture.ts
@@ -1,6 +1,20 @@
-import { Lecture as _Lecture } from 'twinte-parser'
+import { Day, Module } from 'twinte-parser'
 
-export interface LectureEntity extends _Lecture {
+export interface LectureEntity {
+  lectureCode: string
+  name: string
+  credits: number
+  overview: string
+  remarks: string
+  type: number
+  details: {
+    module: Module
+    day: Day
+    period: number
+    room: string
+  }[]
+  instructor: string
   twinte_lecture_id: string
   year: number
+  standardYear: number[]
 }

--- a/src/entity/period.ts
+++ b/src/entity/period.ts
@@ -19,6 +19,7 @@ export interface UserLectureEntity {
   memo: string
   lecture_name: string
   instructor: string
+  credits: number
 }
 
 export interface TimetableEntity extends PeriodEntity {

--- a/src/infrastructure/database/index.ts
+++ b/src/infrastructure/database/index.ts
@@ -11,6 +11,7 @@ import { SubstituteDay } from './orm/substituteDay'
 import { Session } from './orm/session'
 import { getLogger } from 'log4js'
 import { PaymentUser } from '../payment/orm/paymentUser'
+import { LectureStandardYear } from './orm/lectureStandardYear'
 
 const logger = getLogger('database')
 
@@ -37,6 +38,7 @@ export async function connect(): Promise<Connection> {
       entities: [
         Lecture,
         LectureDate,
+        LectureStandardYear,
         User,
         UserAuthentication,
         Period,

--- a/src/infrastructure/database/kdbRemoteLectureRepository.ts
+++ b/src/infrastructure/database/kdbRemoteLectureRepository.ts
@@ -9,10 +9,14 @@ export class KdbRemoteLectureRepository implements RemoteLectureRepository {
     const csv = await downloadKDB(year)
     const lectures = parseKDB(csv)
 
-    return lectures.map(el => ({
-      ...el,
-      year,
-      twinte_lecture_id: ''
-    }))
+    return lectures.map(el => {
+      const { year: standardYear, ...tmp } = el
+      return {
+        ...tmp,
+        year,
+        standardYear,
+        twinte_lecture_id: ''
+      }
+    })
   }
 }

--- a/src/infrastructure/database/orm/lecture.ts
+++ b/src/infrastructure/database/orm/lecture.ts
@@ -1,5 +1,6 @@
 import { Column, Entity, OneToMany, PrimaryColumn, Unique } from 'typeorm'
 import { LectureDate } from './lectureDate'
+import { LectureStandardYear } from './lectureStandardYear'
 
 @Entity()
 @Unique('UQ_YEAR_LECTURE_CODE', ['year', 'lecture_code'])
@@ -23,6 +24,40 @@ export class Lecture {
 
   @Column()
   instructor!: string
+
+  @Column({
+    type: 'numeric',
+    default: 0
+  })
+  credits!: number
+
+  @Column({
+    type: 'varchar',
+    length: 2048,
+    default: ''
+  })
+  overview!: string
+
+  @Column({
+    type: 'varchar',
+    length: 2048,
+    default: ''
+  })
+  remarks!: string
+
+  @Column({
+    type: 'smallint'
+  })
+  type!: number
+
+  @OneToMany(
+    () => LectureStandardYear,
+    lectureStandardYear => lectureStandardYear.lecture,
+    {
+      cascade: true
+    }
+  )
+  standardYear!: LectureStandardYear[]
 
   @OneToMany(
     () => LectureDate,

--- a/src/infrastructure/database/orm/lectureStandardYear.ts
+++ b/src/infrastructure/database/orm/lectureStandardYear.ts
@@ -1,0 +1,12 @@
+import { Column, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm'
+import { Lecture } from './lecture'
+
+@Entity()
+export class LectureStandardYear {
+  @PrimaryGeneratedColumn()
+  id!: number
+  @ManyToOne(() => Lecture)
+  lecture!: Lecture
+  @Column()
+  standardYear!: number
+}

--- a/src/infrastructure/database/orm/userLecture.ts
+++ b/src/infrastructure/database/orm/userLecture.ts
@@ -54,4 +54,10 @@ export class UserLecture {
 
   @Column()
   memo!: string
+
+  @Column({
+    type: 'numeric',
+    default: 0
+  })
+  credits!: number
 }

--- a/src/infrastructure/database/pLectureRepository.ts
+++ b/src/infrastructure/database/pLectureRepository.ts
@@ -8,6 +8,7 @@ import uuid = require('uuid')
 import { getConnection } from './index'
 import _cliProgress from 'cli-progress'
 import { getLogger } from 'log4js'
+import { LectureStandardYear } from './orm/lectureStandardYear'
 
 const logger = getLogger('database')
 
@@ -23,7 +24,7 @@ export class PLectureRepository implements LectureRepository {
     twinteLectureId: string
   ): Promise<LectureEntity | undefined> {
     const pLec = await this.repository.findOne(twinteLectureId, {
-      relations: ['dates']
+      relations: ['dates', 'standardYear']
     })
 
     if (!pLec) return undefined
@@ -59,7 +60,7 @@ export class PLectureRepository implements LectureRepository {
           lecture_code: lec.lectureCode,
           year: lec.year
         },
-        { relations: ['dates'] }
+        { relations: ['dates', 'standardYear'] }
       )
 
       if (!updateTarget) {
@@ -81,6 +82,16 @@ export class PLectureRepository implements LectureRepository {
         ld.room = el.room
         return ld
       })
+      updateTarget.credits = lec.credits
+      updateTarget.overview = lec.overview
+      updateTarget.remarks = lec.overview
+      updateTarget.type = lec.type
+      updateTarget.standardYear = lec.standardYear.map(e => {
+        const y = new LectureStandardYear()
+        y.standardYear = e
+        return y
+      })
+
       await this.pLecToLec(await this.repository.save(updateTarget))
       bar.update(i)
     }
@@ -96,7 +107,12 @@ export class PLectureRepository implements LectureRepository {
       lectureCode: pLec.lecture_code,
       name: pLec.lecture_name,
       details: pLec.dates,
-      instructor: pLec.instructor
+      instructor: pLec.instructor,
+      credits: pLec.credits,
+      overview: pLec.overview,
+      remarks: pLec.remarks,
+      type: pLec.type,
+      standardYear: pLec.standardYear.map(e => e.standardYear)
     }
   }
 
@@ -106,7 +122,7 @@ export class PLectureRepository implements LectureRepository {
   ): Promise<LectureEntity | undefined> {
     const res = await this.repository.findOne(
       { year, lecture_code },
-      { relations: ['dates'] }
+      { relations: ['dates', 'standardYear'] }
     )
     if (!res) return undefined
     return this.pLecToLec(res)

--- a/src/infrastructure/database/pLectureRepository.ts
+++ b/src/infrastructure/database/pLectureRepository.ts
@@ -37,7 +37,7 @@ export class PLectureRepository implements LectureRepository {
     keyword: string
   ): Promise<LectureEntity[]> {
     const pLecs = await this.repository.find({
-      relations: ['dates'],
+      relations: ['dates', 'standardYear'],
       where: [
         { lecture_name: Like(`%${keyword}%`), year },
         { lecture_code: Like(`${keyword}%`), year },
@@ -84,7 +84,7 @@ export class PLectureRepository implements LectureRepository {
       })
       updateTarget.credits = lec.credits
       updateTarget.overview = lec.overview
-      updateTarget.remarks = lec.overview
+      updateTarget.remarks = lec.remarks
       updateTarget.type = lec.type
       updateTarget.standardYear = lec.standardYear.map(e => {
         const y = new LectureStandardYear()

--- a/src/infrastructure/database/pLectureRepository.ts
+++ b/src/infrastructure/database/pLectureRepository.ts
@@ -108,7 +108,7 @@ export class PLectureRepository implements LectureRepository {
       name: pLec.lecture_name,
       details: pLec.dates,
       instructor: pLec.instructor,
-      credits: pLec.credits,
+      credits: Number(pLec.credits),
       overview: pLec.overview,
       remarks: pLec.remarks,
       type: pLec.type,

--- a/src/infrastructure/database/pUserLectureRepository.ts
+++ b/src/infrastructure/database/pUserLectureRepository.ts
@@ -62,7 +62,8 @@ export class PUserLectureRepository implements UserLectureRepository {
     user: UserEntity,
     year: number,
     lecture_name: string,
-    instructor: string
+    instructor: string,
+    credits: number
   ): Promise<UserLectureEntity> {
     const newUserLecture = new pUserLecture()
     newUserLecture.user_lecture_id = uuid()
@@ -73,6 +74,7 @@ export class PUserLectureRepository implements UserLectureRepository {
     newUserLecture.late = 0
     newUserLecture.year = year
     newUserLecture.memo = ''
+    newUserLecture.credits = credits
     const u = await this.userRepository.findOne({ ...user })
     if (!u) throw Error('存在するはずのユーザーが見つかりません')
     newUserLecture.user = u
@@ -135,6 +137,7 @@ export class PUserLectureRepository implements UserLectureRepository {
     target.attendance = userLecture.attendance
     target.late = userLecture.late
     target.memo = userLecture.memo
+    target.credits = userLecture.credits
     return this.pUserLectureToUserLecture(
       await this.userLectureRepository.save(target)
     )

--- a/src/infrastructure/database/pUserLectureRepository.ts
+++ b/src/infrastructure/database/pUserLectureRepository.ts
@@ -24,6 +24,17 @@ export class PUserLectureRepository implements UserLectureRepository {
     this.periodRepository = getConnection().getRepository(pPeriod)
   }
 
+  async getUserLectureByYear(
+    user: UserEntity,
+    year: number
+  ): Promise<UserLectureEntity[]> {
+    const res = await this.userLectureRepository.find({
+      where: { user, year },
+      relations: ['twinte_lecture']
+    })
+    return res.map(el => this.pUserLectureToUserLecture(el))
+  }
+
   async findUserLectureById(
     user: UserEntity,
     user_lecture_id: string

--- a/src/infrastructure/database/pUserLectureRepository.ts
+++ b/src/infrastructure/database/pUserLectureRepository.ts
@@ -96,6 +96,7 @@ export class PUserLectureRepository implements UserLectureRepository {
     newUserLecture.absence = 0
     newUserLecture.late = 0
     newUserLecture.memo = ''
+    newUserLecture.credits = srcLecture.credits
     const u = await this.userRepository.findOne({ ...user })
     if (!u) throw Error('存在するはずのユーザーが見つかりません')
     newUserLecture.user = u
@@ -161,7 +162,8 @@ export class PUserLectureRepository implements UserLectureRepository {
       late: p.late,
       memo: p.memo,
       lecture_name: p.lecture_name,
-      instructor: p.instructor
+      instructor: p.instructor,
+      credits: p.credits
     }
   }
 

--- a/src/infrastructure/database/pUserLectureRepository.ts
+++ b/src/infrastructure/database/pUserLectureRepository.ts
@@ -177,7 +177,7 @@ export class PUserLectureRepository implements UserLectureRepository {
       memo: p.memo,
       lecture_name: p.lecture_name,
       instructor: p.instructor,
-      credits: p.credits
+      credits: Number(p.credits) //numeric型は厳密にjsのnumber型で表せないためstringで帰ってくる
     }
   }
 

--- a/src/infrastructure/rest-api/routing/userLectureService.ts
+++ b/src/infrastructure/rest-api/routing/userLectureService.ts
@@ -7,6 +7,7 @@ import {
   POST,
   PreProcessor,
   PUT,
+  QueryParam,
   ServiceContext
 } from 'typescript-rest'
 import { UserLectureController } from '../../../interface/controller/userLectureController'
@@ -68,14 +69,20 @@ export class UserLectureService {
   }
 
   /**
-   * ユーザーが保持しているユーザー講義をすべて取得する
+   * ユーザーが保持しているユーザー講義を取得する
    */
   @GET
   @Response<UserLectureEntity>(200, 'ユーザー講義一覧')
-  getAllUserLecture() {
-    return this.userLectureController.getAllUserLectures(
-      this.context.request.user!!
-    )
+  getAllUserLecture(@QueryParam('year') year?: number) {
+    if (year)
+      return this.userLectureController.getUserLectureByYear(
+        this.context.request.user!!,
+        year
+      )
+    else
+      return this.userLectureController.getAllUserLectures(
+        this.context.request.user!!
+      )
   }
 
   /**

--- a/src/infrastructure/rest-api/routing/userLectureService.ts
+++ b/src/infrastructure/rest-api/routing/userLectureService.ts
@@ -42,12 +42,14 @@ export class UserLectureService {
     year: number
     lecture_name: string
     instructor: string
+    credits: number
   }) {
     return this.userLectureController.createCustomUserLecture(
       this.context.request.user!!,
       params.year,
       params.lecture_name,
-      params.instructor
+      params.instructor,
+      params.credits
     )
   }
 

--- a/src/interactor/createUserLectureInteractor.ts
+++ b/src/interactor/createUserLectureInteractor.ts
@@ -19,13 +19,15 @@ export class CreateUserLectureInteractor implements CreateUserLectureUseCase {
     user: UserEntity,
     year: number,
     lecture_name: string,
-    instructor: string
+    instructor: string,
+    credits: number
   ): Promise<UserLectureEntity> {
     return this.userLectureRepository.createCustomUserLecture(
       user,
       year,
       lecture_name,
-      instructor
+      instructor,
+      credits
     )
   }
 
@@ -71,7 +73,7 @@ export class CreateUserLectureInteractor implements CreateUserLectureUseCase {
     if (
       isConflicts
         // 不明は除く
-        .filter(e => e && (e.module != Module.Unknown && e.day != Day.Unknown))
+        .filter(e => e && e.module != Module.Unknown && e.day != Day.Unknown)
         .some(e => e)
     )
       throw new Error('重複する時限が存在します')

--- a/src/interactor/createUserLectureInteractor.ts
+++ b/src/interactor/createUserLectureInteractor.ts
@@ -73,7 +73,13 @@ export class CreateUserLectureInteractor implements CreateUserLectureUseCase {
     if (
       isConflicts
         // 不明は除く
-        .filter(e => e && e.module != Module.Unknown && e.day != Day.Unknown)
+        .filter(
+          e =>
+            e &&
+            e.module != Module.Unknown &&
+            e.day != Day.Unknown &&
+            e.day != Day.Intensive
+        )
         .some(e => e)
     )
       throw new Error('重複する時限が存在します')

--- a/src/interactor/findUserLectureInteractor.ts
+++ b/src/interactor/findUserLectureInteractor.ts
@@ -24,4 +24,11 @@ export class FindUserLectureInteractor implements FindUserLectureUseCase {
   getLectureCodes(user: UserEntity, year: number): Promise<string[]> {
     return this.userLectureRepository.getLectureCodes(user, year)
   }
+
+  getUserLectureByYear(
+    user: UserEntity,
+    year: number
+  ): Promise<UserLectureEntity[]> {
+    return this.userLectureRepository.getUserLectureByYear(user, year)
+  }
 }

--- a/src/interface/controller/userLectureController.ts
+++ b/src/interface/controller/userLectureController.ts
@@ -22,13 +22,15 @@ export class UserLectureController {
     user: UserEntity,
     year: number,
     lecture_name: string,
-    instructor: string
+    instructor: string,
+    credits: number
   ): Promise<UserLectureEntity> {
     return this.createUserLectureUseCase.createCustomUserLecture(
       user,
       year,
       lecture_name,
-      instructor
+      instructor,
+      credits
     )
   }
 

--- a/src/interface/controller/userLectureController.ts
+++ b/src/interface/controller/userLectureController.ts
@@ -43,6 +43,13 @@ export class UserLectureController {
     return this.findUserLectureUseCase.getAllUserLectures(user)
   }
 
+  getUserLectureByYear(
+    user: UserEntity,
+    year: number
+  ): Promise<UserLectureEntity[]> {
+    return this.findUserLectureUseCase.getUserLectureByYear(user, year)
+  }
+
   removeUserLecture(
     user: UserEntity,
     user_lecture_id: string

--- a/src/interface/repository/userLectureRepository.ts
+++ b/src/interface/repository/userLectureRepository.ts
@@ -7,6 +7,10 @@ export interface UserLectureRepository {
     user_lecture_id: string
   ): Promise<UserLectureEntity | undefined>
   getAllUserLecture(user: UserEntity): Promise<UserLectureEntity[]>
+  getUserLectureByYear(
+    user: UserEntity,
+    year: number
+  ): Promise<UserLectureEntity[]>
   createCustomUserLecture(
     user: UserEntity,
     year: number,

--- a/src/interface/repository/userLectureRepository.ts
+++ b/src/interface/repository/userLectureRepository.ts
@@ -11,11 +11,13 @@ export interface UserLectureRepository {
     user: UserEntity,
     year: number
   ): Promise<UserLectureEntity[]>
+
   createCustomUserLecture(
     user: UserEntity,
     year: number,
     lecture_name: string,
-    instructor: string
+    instructor: string,
+    credits: number
   ): Promise<UserLectureEntity>
   createUserLecture(
     user: UserEntity,

--- a/src/usecase/createUserLectureUseCase.ts
+++ b/src/usecase/createUserLectureUseCase.ts
@@ -11,6 +11,7 @@ export interface CreateUserLectureUseCase {
     user: UserEntity,
     year: number,
     lecture_name: string,
-    instructor: string
+    instructor: string,
+    credits: number
   ): Promise<UserLectureEntity>
 }

--- a/src/usecase/findUserLectureUseCase.ts
+++ b/src/usecase/findUserLectureUseCase.ts
@@ -6,6 +6,10 @@ export interface FindUserLectureUseCase {
     user: UserEntity,
     user_lecture_id: string
   ): Promise<UserLectureEntity | undefined>
+  getUserLectureByYear(
+    user: UserEntity,
+    year: number
+  ): Promise<UserLectureEntity[]>
   getAllUserLectures(user: UserEntity): Promise<UserLectureEntity[]>
   getLectureCodes(user: UserEntity, year: number): Promise<string[]>
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5974,10 +5974,10 @@ tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
   integrity sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=
 
-twinte-parser@^1.2.3:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/twinte-parser/-/twinte-parser-1.2.3.tgz#6633e346428f4b5bd57c543dbd1bf68efc10afd9"
-  integrity sha512-qXdt1emq3MV9WzCyLtq1ogOO0ZnCkgCMsB4MmEvAQ2r6cW8taYi7joE75uc36Uc7sye3L49xMY+6Os+3dz5jgQ==
+twinte-parser@1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/twinte-parser/-/twinte-parser-1.3.1.tgz#d0501dc5b2372211d4738881636916619de738fd"
+  integrity sha512-doY/FULL0OcyEOnOSOjsVzPDqafSGcw5s0bA8TzqXgzgotcJKS3Kr0yUu+AMKkyScpzpKN0NvE3PnM0j+Mvcjg==
   dependencies:
     axios "^0.19.0"
     cli-progress "^2.1.1"


### PR DESCRIPTION
#40

変更内容
- 検索結果のlecture型に以下の値追加
```typescript
 interface LectureEntity {
 //...
  credits: number // 単位数
  overview: string // 授業概要
  remarks: string // 備考
  type: number // 1～8の数値で授業形態を表してるらしい（kdb参照）
  standardYear: number[] // 標準履修年次
// .....
}
```

- UserLecture型にcredits を追加

-  `/user-lectures?year=2020` みたいなことができる
`/user-lectures/?year=2020` で帰ってくる配列内の `credits` を集計すると2020年度のユーザーの履修単位数がわかる

備考
マージした後、手動でやらなきゃいけない事があるので夜中にマージしたさがある